### PR TITLE
bw tests wip

### DIFF
--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -14,7 +14,7 @@ contract OpolisPay {
     address[] public supportedTokens; //Tokens that can be sent. 
     address public opolisAdmin; //Should be Opolis multi-sig for security
     address payable public destination; // Where funds are liquidated 
-    address private opolisHelper; //Can be bot wallet for convenience 
+    address public opolisHelper; //Can be bot wallet for convenience 
     
     uint256[] public payrollIds; //List of payrollIds associated with payments
     

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,10 @@ describe("payroll works", function () {
     const payrollID1 = 001;
     const payrollID2 = 002;
 
-    
+    const payrollAmt1 = ethers.utils.parseUnits("2500000000000000000000")
+    const payrollAmt2 = ethers.utils.parseUnits("3000000000000000000000")
+
+
 
     beforeEach(async () => {
 
@@ -43,7 +46,94 @@ describe("payroll works", function () {
         expect(await payroll.opolisAdmin()).to.equal(opolisAdmin.address);
     });
 
+    it("OpolisHelper addresses should be set correctly", async function () {
+        const [,opolisHelper] = await ethers.getSigners();
+        expect(await payroll.opolisHelper()).to.equal(opolisHelper.address);
+    });
+
     it("TestToken should be whitelisted", async function () {
         expect(await payroll.supportedTokens(0)).to.equal(testToken.address);
     });
+
+    it("Let's you pay payroll with correct inputs", async function () {
+        const payment = await ethers.payPayroll(testToken.address, payrollAmt1, payrollID1);
+        expect(await payment.token).to.equal(testToken.address);
+        expect(payment.amount).to.equal(payrollAmt1);
+        expect(payment.payrollId).to.equal(payrollID1);
+    });
+
+    it("Requires you pay with a whitelisted token", async function () {
+        const payment = await ethers.payPayroll(testToken.address, payrollAmt1, payrollID1);
+        
+    });
+
+    it("Requires you to enter a valid, non-duplicative payroll Id", async function () {
+        const payment = await ethers.payPayroll(testToken.address, payrollAmt1, payrollID1);
+        
+    });
+
+    it("Requires you to send a payroll amount above 0", async function () {
+        const payment = await ethers.payPayroll(testToken.address, payrollAmt1, payrollID1);
+        
+    });
+
+    it("Let's you stake with correct inputs", async function () {
+        const payment = await ethers.payPayroll(testToken.address, payrollAmt1, payrollID1);
+        expect(await payment.token).to.equal(testToken.address);
+        expect(payment.amount).to.equal(payrollAmt1);
+        expect(payment.payrollId).to.equal(payrollID1);
+    });
+
+    it("Requires you pay with a whitelisted token or ETH", async function () {
+        const payment = await ethers.payPayroll(testToken.address, payrollAmt1, payrollID1);
+        
+    });
+
+    it("Requires you stake with a memberId", async function () {
+        const payment = await ethers.payPayroll(testToken.address, payrollAmt1, payrollID1);
+        
+    });
+
+    it("Requires you to stake with an amount over 0", async function () {
+        const payment = await ethers.payPayroll(testToken.address, payrollAmt1, payrollID1);
+        
+    });
+
+    it("Can withdraw one payroll", async function () {
+        const payment = await ethers.payPayroll(testToken.address, payrollAmt1, payrollID1);
+        
+    });
+
+    it("Can withdraw more than one payrolls", async function () {
+       
+        
+    });
+
+
+    it("Cannot withdraw a payroll with a bad payrollId'", async function () {
+        
+        
+    });
+
+    it("Can clear balance if admin'", async function () {
+        
+        
+    });
+
+    it("Only Admin can update configs'", async function () {
+        
+        
+    });
+
+    it("Not admin, cannot update configuration", async function () {
+        
+        
+    });
+
+
+
+
+ 
+
+
 })


### PR DESCRIPTION
Changed Opolis Helper Address to public address -- the helper is meant to allow us to set up a bot or shared admin address to trigger liquidations to Wyre. 

Added more tests, some of which are mostly scaffolds. 