### PR TITLE
Audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Simple way for tracking crypto payroll payments for Opolis crypto payroll. This 
 
 The idea is verify when a payroll has been paid based on the user paying their payroll via our UI, where we'll programmatically submit the payrollId along with the actual payment. The other goal is to give our operations team a way to ensure 1) new member deposit in crypto are either immediately sent to Wyre, if paid in ETH, or 2) withdraw batches of new member stakes and crypto payrolls at their discretion. 
 
+## Deployments:
+
+Ropsten: [0x77c7678911647eD74A9997C5412A4DAE2d6BEE77](https://ropsten.etherscan.io/address/0x77c7678911647eD74A9997C5412A4DAE2d6BEE77)
+
 ## Core Functions 
 
 payParoll() - Function to allow a transfer of whitelisted ERC20 tokens along with the corresponding payrollID for that members' payroll. We just use payrollID rather than other information to make it harder to associate a payroll with any particular member. 

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -35,6 +35,9 @@ error InvalidStake();
 /// @dev setting one of the role to zero address
 error ZeroAddress();
 
+/// @dev withdrawing non whitelisted token
+error InvalidToken();
+
 /// @dev whitelisting and empty list of tokens
 error ZeroTokens();
 
@@ -48,7 +51,7 @@ error DirectTransfer();
 /// @notice Minimalist Contract for Crypto Payroll Payments
 contract OpolisPay {
     using SafeERC20 for IERC20;
-    
+
     address[] public supportedTokens; //Tokens that can be sent. 
     address public opolisAdmin; //Should be Opolis multi-sig for security
     address payable public destination; // Where funds are liquidated 
@@ -172,12 +175,14 @@ contract OpolisPay {
             uint256 amount = _payrollAmounts[i];
             
             if (!payrollWithdrawn[id]) {
-                for (uint8 j = 0; j < supportedTokens.length; j++) {
+                uint8 j;
+                for (j; j < supportedTokens.length; j++) {
                     if (supportedTokens[j] == token) {
                         withdrawAmounts[j] += amount;
                         break;
                     }
                 }
+                if (j == supportedTokens.length) revert InvalidToken();
                 payrollWithdrawn[id] = true;
                 
                 emit OpsPayrollWithdraw(token, id, amount);
@@ -209,12 +214,14 @@ contract OpolisPay {
             uint256 amount = _stakeAmounts[i];
             
             if (!stakeWithdrawn[id]) {
-                for (uint8 j = 0; j < supportedTokens.length; j++) {
+                uint8 j;
+                for (j; j < supportedTokens.length; j++) {
                     if (supportedTokens[j] == token) {
                         withdrawAmounts[j] += amount;
                         break;
                     }
                 }
+                if (j == supportedTokens.length) revert InvalidToken();
                 stakeWithdrawn[id] = true;
                 
                 emit OpsStakeWithdraw(token, id, amount);

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -1,9 +1,8 @@
 pragma solidity 0.8.5;
 
 // SPDX-License-Identifier: LGPLv3
-
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 /// @notice custom errors for revert statements
@@ -42,6 +41,7 @@ error DirectTransfer();
 /// @title OpolisPay
 /// @notice Minimalist Contract for Crypto Payroll Payments
 contract OpolisPay {
+    using SafeERC20 for IERC20;
     
     address[] public supportedTokens; //Tokens that can be sent. 
     address public opolisAdmin; //Should be Opolis multi-sig for security
@@ -115,7 +115,7 @@ contract OpolisPay {
         if (payrollId == 0) revert InvalidPayroll();
         if (amount == 0) revert InvalidAmount();
         
-        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
         payrollIds.push(payrollId);
         
         emit Paid(msg.sender, token, payrollId, amount); 
@@ -139,7 +139,7 @@ contract OpolisPay {
         if (msg.value > 0 && token == address(0)){
             destination.transfer(msg.value);
         } else {
-            IERC20(token).transferFrom(msg.sender, address(this), amount);
+            IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
         }
         stakes.push(memberId);
 
@@ -317,7 +317,7 @@ contract OpolisPay {
     }
 
     function _withdraw(address token, uint256 amount) internal {
-        IERC20(token).transfer(destination, amount);
+        IERC20(token).safeTransfer(destination, amount);
     }
     
 }

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -63,9 +63,9 @@ contract OpolisPay {
     event OpsPayrollWithdraw(address token, uint256 payrollId, uint256 amount);
     event OpsStakeWithdraw(address token, uint256 stakeId, uint256 amount);
     event Sweep(address token, uint256 amount);
-    event NewDestination(address destination);
-    event NewAdmin(address opolisAdmin);
-    event NewHelper(address newHelper);
+    event NewDestination(address oldDestination, address destination);
+    event NewAdmin(address oldAdmin, address opolisAdmin);
+    event NewHelper(address oldHelper, address newHelper);
     event NewToken(address[] newTokens);
     
     mapping (uint256 => bool) private stakes; //Tracks used stake ids
@@ -276,9 +276,10 @@ contract OpolisPay {
     function updateDestination(address payable newDestination) external onlyAdmin returns (address){
         
         if (newDestination == address(0)) revert ZeroAddress();
+
+        emit NewDestination(destination, newDestination);
         destination = newDestination;
         
-        emit NewDestination(destination);
         return destination;
     }
     
@@ -289,9 +290,10 @@ contract OpolisPay {
     function updateAdmin(address newAdmin) external onlyAdmin returns (address){
         
         if (newAdmin == address(0)) revert ZeroAddress();
+
+        emit NewAdmin(opolisAdmin, newAdmin);
         opolisAdmin = newAdmin;
       
-        emit NewAdmin(opolisAdmin);
         return opolisAdmin;
     }
     
@@ -302,9 +304,10 @@ contract OpolisPay {
     function updateHelper(address newHelper) external onlyAdmin returns (address){
         
         if (newHelper == address(0)) revert ZeroAddress();
+
+        emit NewHelper(opolisHelper, newHelper);
         opolisHelper = newHelper;
       
-        emit NewHelper(opolisHelper);
         return opolisHelper;
     }
     

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -49,7 +49,7 @@ error DirectTransfer();
 
 /// @title OpolisPay
 /// @notice Minimalist Contract for Crypto Payroll Payments
-contract OpolisPay {
+contract OpolisPay is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     address[] private supportedTokens; //Tokens that can be sent. 
@@ -117,7 +117,7 @@ contract OpolisPay {
      /// @param amount the amount due for their payroll -- up to user / front-end to match 
      /// @param payrollId the way we'll associate payments with members' invoices 
      
-    function payPayroll(address token, uint256 amount, uint256 payrollId) external {
+    function payPayroll(address token, uint256 amount, uint256 payrollId) external nonReentrant {
         
         if (!whitelisted[token]) revert NotWhitelisted();
         if (payrollId == 0) revert InvalidPayroll();
@@ -135,7 +135,7 @@ contract OpolisPay {
     /// @param amount the amount due for staking -- up to user / front-end to match 
     /// @param memberId the way we'll associate the stake with a new member 
     
-    function memberStake(address token, uint256 amount, uint256 memberId) public payable {
+    function memberStake(address token, uint256 amount, uint256 memberId) public payable nonReentrant {
         if (
             !(
                 (whitelisted[token] && amount !=0) || (token == address(0) && msg.value != 0)

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -169,7 +169,7 @@ contract OpolisPay {
         uint256[] calldata _payrollAmounts
     ) external onlyOpolis {
         uint256[] memory withdrawAmounts = new uint256[](supportedTokens.length);
-        for (uint16 i = 0; i < _payrollIds.length; i++){
+        for (uint256 i = 0; i < _payrollIds.length; i++){
             uint256 id = _payrollIds[i];
             if (!payrollIds[id]) revert InvalidPayroll();
 
@@ -177,7 +177,7 @@ contract OpolisPay {
             uint256 amount = _payrollAmounts[i];
             
             if (!payrollWithdrawn[id]) {
-                uint8 j;
+                uint256 j;
                 for (j; j < supportedTokens.length; j++) {
                     if (supportedTokens[j] == token) {
                         withdrawAmounts[j] += amount;
@@ -191,7 +191,7 @@ contract OpolisPay {
             }
         }
 
-        for (uint16 i = 0; i < withdrawAmounts.length; i++){
+        for (uint256 i = 0; i < withdrawAmounts.length; i++){
             uint256 amount = withdrawAmounts[i];
             if (amount > 0) {
                 _withdraw(supportedTokens[i], amount);
@@ -210,7 +210,7 @@ contract OpolisPay {
         uint256[] calldata _stakeAmounts
     ) external onlyOpolis {
         uint256[] memory withdrawAmounts = new uint256[](supportedTokens.length);
-        for (uint16 i = 0; i < _stakeIds.length; i++){
+        for (uint256 i = 0; i < _stakeIds.length; i++){
             uint256 id = _stakeIds[i];
             if (!stakes[id]) revert InvalidStake();
 
@@ -218,7 +218,7 @@ contract OpolisPay {
             uint256 amount = _stakeAmounts[i];
             
             if (!stakeWithdrawn[id]) {
-                uint8 j;
+                uint256 j;
                 for (j; j < supportedTokens.length; j++) {
                     if (supportedTokens[j] == token) {
                         withdrawAmounts[j] += amount;
@@ -232,7 +232,7 @@ contract OpolisPay {
             }
         }
 
-        for (uint16 i = 0; i < withdrawAmounts.length; i++){
+        for (uint256 i = 0; i < withdrawAmounts.length; i++){
             uint256 amount = withdrawAmounts[i];
             if (amount > 0) {
                 _withdraw(supportedTokens[i], amount);

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -52,10 +52,10 @@ error DirectTransfer();
 contract OpolisPay {
     using SafeERC20 for IERC20;
 
-    address[] public supportedTokens; //Tokens that can be sent. 
-    address public opolisAdmin; //Should be Opolis multi-sig for security
-    address payable public destination; // Where funds are liquidated 
-    address public opolisHelper; //Can be bot wallet for convenience 
+    address[] private supportedTokens; //Tokens that can be sent. 
+    address private opolisAdmin; //Should be Opolis multi-sig for security
+    address payable private destination; // Where funds are liquidated 
+    address private opolisHelper; //Can be bot wallet for convenience 
     
     event SetupComplete(address payable destination, address admin, address helper, address[] tokens);
     event Staked(address staker, address token, uint256 amount, uint256 memberId);
@@ -68,8 +68,8 @@ contract OpolisPay {
     event NewHelper(address newHelper);
     event NewToken(address[] newTokens);
     
-    mapping (uint256 => bool) public stakes; //Tracks used stake ids
-    mapping (uint256 => bool) public payrollIds; //Tracks used payroll ids
+    mapping (uint256 => bool) private stakes; //Tracks used stake ids
+    mapping (uint256 => bool) private payrollIds; //Tracks used payroll ids
     mapping (uint256 => bool) public payrollWithdrawn; //Tracks payroll withdrawals
     mapping (uint256 => bool) public stakeWithdrawn; //Tracks stake withdrawals
     mapping (address => bool) public whitelisted; //Tracks whitelisted tokens

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -52,7 +52,7 @@ error DirectTransfer();
 contract OpolisPay is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    address[] private supportedTokens; //Tokens that can be sent. 
+    address[] public supportedTokens; //Tokens that can be sent. 
     address private opolisAdmin; //Should be Opolis multi-sig for security
     address payable private destination; // Where funds are liquidated 
     address private opolisHelper; //Can be bot wallet for convenience 

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -144,7 +144,8 @@ contract OpolisPay {
         // @dev function for auto transfering out stakes 
 
         if (msg.value > 0 && token == address(0)){
-            destination.transfer(msg.value);
+            (bool success, ) = destination.call{value: msg.value}("");
+            require(success, "Transfer failed.");
         } else {
             IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
         }

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -171,6 +171,8 @@ contract OpolisPay {
         uint256[] memory withdrawAmounts = new uint256[](supportedTokens.length);
         for (uint16 i = 0; i < _payrollIds.length; i++){
             uint256 id = _payrollIds[i];
+            if (!payrollIds[id]) revert InvalidPayroll();
+
             address token = _payrollTokens[i];
             uint256 amount = _payrollAmounts[i];
             
@@ -210,6 +212,8 @@ contract OpolisPay {
         uint256[] memory withdrawAmounts = new uint256[](supportedTokens.length);
         for (uint16 i = 0; i < _stakeIds.length; i++){
             uint256 id = _stakeIds[i];
+            if (!stakes[id]) revert InvalidStake();
+
             address token = _stakeTokens[i];
             uint256 amount = _stakeAmounts[i];
             

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,5 +1,7 @@
 require("@nomiclabs/hardhat-waffle");
 require("hardhat-gas-reporter");
+require("@nomiclabs/hardhat-etherscan");
+
 const config = require("./config.json");
 
 // This is a sample Hardhat task. To learn how to create your own go to

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "hardhat-gas-reporter": "^1.0.4"
   },
   "dependencies": {
+    "@nomiclabs/hardhat-etherscan": "^3.0.0",
     "@openzeppelin/contracts": "^4.4.2"
   }
 }

--- a/scripts/deploy-test.js
+++ b/scripts/deploy-test.js
@@ -17,7 +17,7 @@ async function main() {
     console.log("Test token deployed to:", TT.address);
 
     console.log("Deploying test payroll contract...");
-    const OpolisPayroll = await ethers.getContractFactory("payroll");
+    const OpolisPayroll = await ethers.getContractFactory("OpolisPay");
     const payroll = await OpolisPayroll.deploy(
       config.wyreAddress, 
       config.opolisAdmin, 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -8,7 +8,7 @@ const ethers = hre.ethers;
 const config = require("../config.json");
 
 async function main() {
-  const OpolisPayroll = await ethers.getContractFactory("payroll");
+  const OpolisPayroll = await ethers.getContractFactory("OpolisPay");
   const payroll = await OpolisPayroll.deploy(
       config.wyreAddress, 
       config.opolisAdmin, 

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,8 @@ describe("payroll works", function () {
   const payrollAmt1 = ethers.utils.parseUnits("2500", 18);
   const payrollAmt2 = ethers.utils.parseUnits("3000", 18);
 
+  let setupTx;
+
   beforeEach(async () => {
     const TestToken = await ethers.getContractFactory("TestToken");
     const OpolisPay = await ethers.getContractFactory("OpolisPay");
@@ -46,22 +48,12 @@ describe("payroll works", function () {
   });
 
   describe("contract setup", () => {
-    it("Destination addresses should be set correctly", async function () {
-      expect(await payroll.destination()).to.equal(opolisDest);
-    });
-
-    it("OpolisAdmin addresses should be set correctly", async function () {
-      const [opolisAdmin] = await ethers.getSigners();
-      expect(await payroll.opolisAdmin()).to.equal(opolisAdmin.address);
-    });
-
-    it("OpolisHelper addresses should be set correctly", async function () {
-      const [, opolisHelper] = await ethers.getSigners();
-      expect(await payroll.opolisHelper()).to.equal(opolisHelper.address);
-    });
-
-    it("TestToken should be whitelisted", async function () {
-      expect(await payroll.supportedTokens(0)).to.equal(testToken.address);
+    it("Setup should be done correctly", async function () {
+      expect(payroll.deployTransaction)
+        .to.emit(payroll, "SetupComplete")
+        .withArgs(opolisDest, opolisAdmin.address, opolisHelper.address, [
+          testToken.address,
+        ]);
     });
 
     it("Can't send eth directly to contract", async () => {
@@ -525,19 +517,16 @@ describe("payroll works", function () {
     it("update destination", async () => {
       const tx = await payroll.updateDestination(newAddress);
       expect(tx).to.emit(payroll, "NewDestination").withArgs(newAddress);
-      expect(await payroll.destination()).to.equal(newAddress);
     });
 
     it("update admin", async () => {
       const tx = await payroll.updateAdmin(newAddress);
       expect(tx).to.emit(payroll, "NewAdmin").withArgs(newAddress);
-      expect(await payroll.opolisAdmin()).to.equal(newAddress);
     });
 
     it("update helper", async () => {
       const tx = await payroll.updateHelper(newAddress);
       expect(tx).to.emit(payroll, "NewHelper").withArgs(newAddress);
-      expect(await payroll.opolisHelper()).to.equal(newAddress);
     });
 
     it("add tokens", async () => {
@@ -548,9 +537,6 @@ describe("payroll works", function () {
       ];
       const tx = await payroll.addTokens(tokens);
       expect(tx).to.emit(payroll, "NewToken").withArgs(tokens);
-      expect(await payroll.supportedTokens(1)).to.equal(tokens[0]);
-      expect(await payroll.supportedTokens(2)).to.equal(tokens[1]);
-      expect(await payroll.supportedTokens(3)).to.equal(tokens[2]);
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -219,13 +219,48 @@ describe("payroll works", function () {
           [payrollAmt1]
         )
       ).to.be.revertedWith("InvalidToken()");
+
+      // stake
+      await testToken.mint(opolisMember2.address, payrollAmt2);
+      await testToken
+        .connect(opolisMember2)
+        .approve(payroll.address, payrollAmt2);
+      await payroll
+        .connect(opolisMember2)
+        .memberStake(testToken.address, payrollAmt2, payrollID2);
       await expect(
         payroll.withdrawStakes(
-          [payrollID1],
+          [payrollID2],
           [testToken2.address],
-          [payrollAmt1]
+          [payrollAmt2]
         )
       ).to.be.revertedWith("InvalidToken()");
+    });
+
+    it("Can't withdraw non existant payroll", async function () {
+      await expect(
+        payroll.withdrawPayrolls(
+          [payrollID2],
+          [testToken.address],
+          [payrollAmt1]
+        )
+      ).to.be.revertedWith("InvalidPayroll()");
+      await expect(
+        payroll.withdrawStakes([payrollID1], [testToken.address], [payrollAmt1])
+      ).to.be.revertedWith("InvalidStake()");
+    });
+
+    it("Can't withdraw non existant stake", async function () {
+      await testToken.mint(opolisMember2.address, payrollAmt2);
+      await testToken
+        .connect(opolisMember2)
+        .approve(payroll.address, payrollAmt2);
+      await payroll
+        .connect(opolisMember2)
+        .memberStake(testToken.address, payrollAmt2, payrollID2);
+      await expect(
+        payroll.withdrawStakes([payrollID1], [testToken.address], [payrollAmt2])
+      ).to.be.revertedWith("InvalidStake()");
     });
 
     it("Can withdraw one payroll", async function () {
@@ -332,6 +367,14 @@ describe("payroll works", function () {
     });
 
     it("Can withdraw more than one stake", async function () {
+      await testToken.mint(opolisMember1.address, payrollAmt1);
+      await testToken
+        .connect(opolisMember1)
+        .approve(payroll.address, payrollAmt1);
+      await payroll
+        .connect(opolisMember1)
+        .memberStake(testToken.address, payrollAmt1, payrollID1);
+
       await testToken.mint(opolisMember2.address, payrollAmt2);
       await testToken
         .connect(opolisMember2)
@@ -354,6 +397,14 @@ describe("payroll works", function () {
     });
 
     it("Cannot withdraw a stake thats already withdrawn", async function () {
+      await testToken.mint(opolisMember1.address, payrollAmt1);
+      await testToken
+        .connect(opolisMember1)
+        .approve(payroll.address, payrollAmt1);
+      await payroll
+        .connect(opolisMember1)
+        .memberStake(testToken.address, payrollAmt1, payrollID1);
+
       const startBalance = await testToken.balanceOf(payroll.address);
       await payroll.withdrawStakes(
         [payrollID1],

--- a/test/test.js
+++ b/test/test.js
@@ -516,17 +516,23 @@ describe("payroll works", function () {
 
     it("update destination", async () => {
       const tx = await payroll.updateDestination(newAddress);
-      expect(tx).to.emit(payroll, "NewDestination").withArgs(newAddress);
+      expect(tx)
+        .to.emit(payroll, "NewDestination")
+        .withArgs(opolisDest, newAddress);
     });
 
     it("update admin", async () => {
       const tx = await payroll.updateAdmin(newAddress);
-      expect(tx).to.emit(payroll, "NewAdmin").withArgs(newAddress);
+      expect(tx)
+        .to.emit(payroll, "NewAdmin")
+        .withArgs(opolisAdmin.address, newAddress);
     });
 
     it("update helper", async () => {
       const tx = await payroll.updateHelper(newAddress);
-      expect(tx).to.emit(payroll, "NewHelper").withArgs(newAddress);
+      expect(tx)
+        .to.emit(payroll, "NewHelper")
+        .withArgs(opolisHelper.address, newAddress);
     });
 
     it("add tokens", async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -211,6 +211,23 @@ describe("payroll works", function () {
         .payPayroll(testToken.address, payrollAmt1, payrollID1);
     });
 
+    it("Can't withdraw non whitelisted token", async function () {
+      await expect(
+        payroll.withdrawPayrolls(
+          [payrollID1],
+          [testToken2.address],
+          [payrollAmt1]
+        )
+      ).to.be.revertedWith("InvalidToken()");
+      await expect(
+        payroll.withdrawStakes(
+          [payrollID1],
+          [testToken2.address],
+          [payrollAmt1]
+        )
+      ).to.be.revertedWith("InvalidToken()");
+    });
+
     it("Can withdraw one payroll", async function () {
       const withdrawTx = await payroll.withdrawPayrolls(
         [payrollID1],

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,14 @@ describe("payroll works", function () {
         .payPayroll(testToken.address, payrollAmt1, payrollID1);
     });
 
+    it("No duplicate payroll ids", async function () {
+      await expect(
+        payroll
+          .connect(opolisMember1)
+          .payPayroll(testToken.address, payrollAmt1, payrollID1)
+      ).to.be.revertedWith("DuplicatePayroll()");
+    });
+
     it("Lets you pay payroll with correct inputs", async function () {
       expect(payment)
         .to.emit(payroll, "Paid")
@@ -121,6 +129,17 @@ describe("payroll works", function () {
       await testToken
         .connect(opolisMember1)
         .approve(payroll.address, payrollAmt1);
+    });
+
+    it("Only one stake per user", async function () {
+      await payroll
+        .connect(opolisMember1)
+        .memberStake(testToken.address, payrollAmt1, payrollID1);
+      await expect(
+        payroll
+          .connect(opolisMember1)
+          .memberStake(testToken.address, payrollAmt1, payrollID1)
+      ).to.be.revertedWith("DuplicateStake()");
     });
 
     it("Let's you stake with correct inputs", async function () {
@@ -243,7 +262,7 @@ describe("payroll works", function () {
       let ids = [];
       let tokens = [];
       let amounts = [];
-      for (let i = 1; i < 150; i++) {
+      for (let i = 10; i < 150; i++) {
         await payroll
           .connect(opolisMember2)
           .payPayroll(testToken.address, "1", i);
@@ -274,7 +293,7 @@ describe("payroll works", function () {
       const withdrawTx = await payroll.withdrawPayrolls(ids, tokens, amounts);
       expect(withdrawTx)
         .to.emit(payroll, "OpsPayrollWithdraw")
-        .withArgs(testToken.address, 1, "1");
+        .withArgs(testToken.address, 10, "1");
     });
 
     it("Cannot withdraw a payroll thats already withdrawn", async function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,7 +194,7 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
 
-"@ethersproject/address@5.5.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.5.0":
+"@ethersproject/address@5.5.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.5.0.tgz#bcc6f576a553f21f3dd7ba17248f81b473c9c78f"
   integrity sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==
@@ -499,6 +499,19 @@
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.4.tgz#288889c338acaf47cabd29020e561d0077b7efcf"
   integrity sha512-7LMR344TkdCYkMVF9LuC9VU2NBIi84akQiwqm7OufpWaDgHbWhuanY53rk3SVAW0E4HBk5xn5wl5+bN5f+Mq5w==
+
+"@nomiclabs/hardhat-etherscan@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.0.0.tgz#06e0d59787f01f1296d829e8d43fece50e7ffff1"
+  integrity sha512-E5s35dCHmzuY6pFqlgTdDGQr2xIyUJ3f91m6e7HYlPGz0FGzad9Nem/y0L7L3FHG4LPYg1UObkQVUzqBjtyAOA==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^5.0.2"
+    debug "^4.1.1"
+    fs-extra "^7.0.1"
+    node-fetch "^2.6.0"
+    semver "^6.3.0"
 
 "@nomiclabs/hardhat-waffle@^2.0.1":
   version "2.0.1"
@@ -1675,7 +1688,7 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bignumber.js@^9.0.0:
+bignumber.js@^9.0.0, bignumber.js@^9.0.1:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.2.tgz#71c6c6bed38de64e24a65ebe16cfcf23ae693673"
   integrity sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==
@@ -1990,6 +2003,14 @@ caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+cbor@^5.0.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-5.2.0.tgz#4cca67783ccd6de7b50ab4ed62636712f287a67c"
+  integrity sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==
+  dependencies:
+    bignumber.js "^9.0.1"
+    nofilter "^1.0.4"
 
 chai@^4.3.4:
   version "4.3.4"
@@ -5498,6 +5519,11 @@ node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
   integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
+
+nofilter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
+  integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
 
 normalize-package-data@^2.3.2:
   version "2.5.0"


### PR DESCRIPTION
Addresses the concerns raised by the audit.

Notes:
- QSP-4 suggests using an Enumerable Map data structure but I'm not sure that really makes sense here since the Open Zeppelin implementation only supports `uint -> address`
- QSP-9 is solved by the solution to QSP-2 which prevents duplicate memberId stakes and duplicate payrollIds