### PR TITLE
update for open enrollment by allowing multiple stakes and updated RDME

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ Simple way for tracking crypto payroll payments for Opolis crypto payroll. This 
 
 The idea is verify when a payroll has been paid based on the user paying their payroll via our UI, where we'll programmatically submit the payrollId along with the actual payment. The other goal is to give our operations team a way to ensure 1) new member deposit in crypto are either immediately sent to Wyre, if paid in ETH, or 2) withdraw batches of new member stakes and crypto payrolls at their discretion. 
 
+## Deploying: 
+Steps for getting up and running: 
+
+1. Pull repo from github
+2. `yarn install`
+3. Create a `./config.json` and fill in using the example file 
+4. Run `yarn test` to run test coverage 
+5. Launch with `npx hardhat run ./scripts/deploy-tests.js` for tests or `npx hardhat run ./scripts/deploy.js --network {{network}}`
+
 ## Deployments:
 
 Mainnet: [0x87C91ac511688138E1452C942663f52cD5E2AbC5](https://etherscan.io/address/0x87C91ac511688138E1452C942663f52cD5E2AbC5)

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -148,8 +148,7 @@ contract OpolisPay is ReentrancyGuard {
         if (memberId == 0) revert NotMember();
 
         // @dev increments the stake id for each member
-        uint256 stakeCount = stakes[memberId];
-        stakes[memberId] = stakeCount + 1; 
+        uint stakeCount = ++stakes[memberId]; 
         
         // @dev function for auto transfering out stakes 
 
@@ -159,7 +158,7 @@ contract OpolisPay is ReentrancyGuard {
             emit Staked(msg.sender, ETH, msg.value, memberId, stakes[memberId]);
         } else {
             IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
-            emit Staked(msg.sender, token, amount, memberId, stakes[memberId]);
+            emit Staked(msg.sender, token, amount, memberId, stakeCount);
         }
         
     }
@@ -169,7 +168,6 @@ contract OpolisPay is ReentrancyGuard {
     /// @param _payrollTokens the tokens the payrolls were paid in
     /// @param _payrollAmounts the amount that was paid
     /// @dev we iterate through payrolls and clear them out with the funds being sent to the destination address
-    
     function withdrawPayrolls(
         uint256[] calldata _payrollIds,
         address[] calldata _payrollTokens,
@@ -185,7 +183,7 @@ contract OpolisPay is ReentrancyGuard {
             
             if (!payrollWithdrawn[id]) {
                 uint256 j;
-                for (j; j < supportedTokens.length; j++) {
+                for (; j < supportedTokens.length; j++) {
                     if (supportedTokens[j] == token) {
                         withdrawAmounts[j] += amount;
                         break;
@@ -230,7 +228,7 @@ contract OpolisPay is ReentrancyGuard {
             
             if (stakeWithdrawn[id] < num) {
                 uint256 j;
-                for (j; j < supportedTokens.length; j++) {
+                for (; j < supportedTokens.length; j++) {
                     if (supportedTokens[j] == token) {
                         withdrawAmounts[j] += amount;
                         break;

--- a/example.config.json
+++ b/example.config.json
@@ -1,3 +1,4 @@
+{
 "daiAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
 "usdcAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
 "usdtAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -10,3 +11,4 @@
 "infura": "",
 "etherscan": "",
 "coinmarketcap": ""
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -57,12 +57,12 @@ module.exports = {
 			gasPrice: 150000000000,
 		},
   },
-  gasReporter: {
-    currency: 'USD',
-    gasPrice: 100,
-    excludeContracts: ['contracts/test'],
-    coinmarketcap: config.coinmarketcap
-  },
+   gasReporter: {
+     currency: 'USD',
+     gasPrice: 100,
+     excludeContracts: ['contracts/test'],
+     coinmarketcap: config.coinmarketcap
+   },
   etherscan: {
     // Your API key for Etherscan
     // Obtain one at https://etherscan.io/

--- a/test/test.js
+++ b/test/test.js
@@ -235,6 +235,7 @@ describe("payroll works", function () {
       await expect(
         payroll.withdrawStakes(
           [payrollID2],
+          [1],
           [testToken2.address],
           [payrollAmt2]
         )
@@ -249,12 +250,9 @@ describe("payroll works", function () {
           [payrollAmt1]
         )
       ).to.be.revertedWith("InvalidPayroll()");
-      await expect(
-        payroll.withdrawStakes([payrollID1], [testToken.address], [payrollAmt1])
-      ).to.be.revertedWith("InvalidStake()");
     });
 
-    it("Can't withdraw non existant stake", async function () {
+    it("Can't pass wrong stake arrays", async function () {
       await testToken.mint(opolisMember2.address, payrollAmt2);
       await testToken
         .connect(opolisMember2)
@@ -263,8 +261,8 @@ describe("payroll works", function () {
         .connect(opolisMember2)
         .memberStake(testToken.address, payrollAmt2, payrollID2);
       await expect(
-        payroll.withdrawStakes([payrollID1], [testToken.address], [payrollAmt2])
-      ).to.be.revertedWith("InvalidStake()");
+        payroll.withdrawStakes([payrollID1], [1,3,4], [testToken.address], [payrollAmt2])
+      ).to.be.revertedWith("InvalidWithdraw()");
     });
 
     it("Can withdraw one payroll", async function () {
@@ -389,15 +387,16 @@ describe("payroll works", function () {
 
       const withdrawTx = await payroll.withdrawStakes(
         [payrollID1, payrollID2],
+        [1,1],
         [testToken.address, testToken.address],
         [payrollAmt1, payrollAmt2]
       );
       expect(withdrawTx)
         .to.emit(payroll, "OpsStakeWithdraw")
-        .withArgs(testToken.address, payrollID1, payrollAmt1);
+        .withArgs(testToken.address, payrollID1, 1, payrollAmt1);
       expect(withdrawTx)
         .to.emit(payroll, "OpsStakeWithdraw")
-        .withArgs(testToken.address, payrollID2, payrollAmt2);
+        .withArgs(testToken.address, payrollID2, 1, payrollAmt2);
     });
 
     it("Cannot withdraw a stake thats already withdrawn", async function () {
@@ -412,12 +411,14 @@ describe("payroll works", function () {
       const startBalance = await testToken.balanceOf(payroll.address);
       await payroll.withdrawStakes(
         [payrollID1],
+        [1],
         [testToken.address],
         [payrollAmt1]
       );
       const midBalance = await testToken.balanceOf(payroll.address);
       await payroll.withdrawStakes(
         [payrollID1],
+        [1],
         [testToken.address],
         [payrollAmt1]
       );
@@ -442,6 +443,7 @@ describe("payroll works", function () {
         .approve(payroll.address, payrollAmt2);
 
       let ids = [];
+      let nums = [];
       let tokens = [];
       let amounts = [];
       for (let i = 1; i < 150; i++) {

--- a/test/test.js
+++ b/test/test.js
@@ -452,6 +452,7 @@ describe("payroll works", function () {
           .memberStake(testToken.address, "1", i);
 
         ids = [...ids, i];
+        nums = [...nums, 1]
         tokens = [...tokens, testToken.address];
         amounts = [...amounts, "1"];
       }
@@ -461,23 +462,25 @@ describe("payroll works", function () {
           .memberStake(testToken2.address, "1", i);
 
         ids = [...ids, i];
+        nums = [...nums, 1]
         tokens = [...tokens, testToken2.address];
         amounts = [...amounts, "1"];
       }
-      for (let i = 300; i < 500; i++) {
+      for (let i = 300; i < 450; i++) {
         await payroll
           .connect(opolisMember2)
           .memberStake(testToken3.address, "1", i);
 
         ids = [...ids, i];
+        nums = [...nums, 1]
         tokens = [...tokens, testToken3.address];
         amounts = [...amounts, "1"];
       }
 
-      const withdrawTx = await payroll.withdrawStakes(ids, tokens, amounts);
+      const withdrawTx = await payroll.withdrawStakes(ids, nums, tokens, amounts);
       expect(withdrawTx)
         .to.emit(payroll, "OpsStakeWithdraw")
-        .withArgs(testToken.address, 1, "1");
+        .withArgs(testToken.address, 1, 1, "1");
     });
 
     it("Can clear balance if admin'", async function () {


### PR DESCRIPTION
Updating contracts to allow for a member to stake multiple times: 
* Remove revert statement for multiple stakes
* Track stakes by number starting at 1 and incrementing that number
* Update test coverage 
* Update example config with brackets for json format 
* Update readme with test and launch instructions 