### PR TITLE
updateable eth liquidation address

### DIFF
--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -301,6 +301,7 @@ contract OpolisPay is ReentrancyGuard {
 
     function updateDestination(address token, address newDestination) external onlyAdmin {
         if (newDestination == ZERO) revert ZeroAddress();
+        if (!whitelisted[token]) revert NotWhitelisted();
 
         address oldDestination = liqDestinations[token];
         liqDestinations[token] = newDestination;

--- a/contracts/OpolisPay.sol
+++ b/contracts/OpolisPay.sol
@@ -79,6 +79,7 @@ contract OpolisPay is ReentrancyGuard {
     event OpsStakeWithdraw(address indexed token, uint256 indexed stakeId, uint256 stakeNumber, uint256 amount);
     event Sweep(address indexed token, uint256 amount);
     event NewDestination(address indexed oldDestination, address indexed token, address indexed destination);
+    event NewDestinationEth(address indexed oldDestination, address indexed destination);
     event NewAdmin(address indexed oldAdmin, address indexed opolisAdmin);
     event NewHelper(address indexed oldHelper, address indexed newHelper);
     event NewTokens(address[] newTokens, address[] newDestinations);
@@ -305,6 +306,15 @@ contract OpolisPay is ReentrancyGuard {
         liqDestinations[token] = newDestination;
 
         emit NewDestination(oldDestination, token, newDestination);
+    }
+
+    function updateEthDestination(address newDestination) external onlyAdmin {
+        if (newDestination == ZERO) revert ZeroAddress();
+
+        address oldDestination = ethLiquidation;
+        ethLiquidation = newDestination;
+
+        emit NewDestinationEth(oldDestination, newDestination);
     }
 
     /// @notice this function is used to replace the admin multi-sig

--- a/test/test.js
+++ b/test/test.js
@@ -615,6 +615,13 @@ describe("payroll works", function () {
       );
     });
 
+    it("update eth destination", async () => {
+      const tx = await payroll.updateEthDestination(newAddress);
+      expect(tx)
+        .to.emit(payroll, "NewDestinationEth")
+        .withArgs(opolisEthLiq, newAddress);
+    });
+
     it("update admin", async () => {
       const tx = await payroll.updateAdmin(newAddress);
       expect(tx)

--- a/test/test.js
+++ b/test/test.js
@@ -604,6 +604,12 @@ describe("payroll works", function () {
       ).to.be.revertedWith("NotPermitted()");
     });
 
+    it("can't update destination on address that is not a whitelisted token", async () => {
+      await expect(
+        payroll.updateDestination(ethAddress, newAddress)
+      ).to.be.revertedWith("NotWhitelisted()");
+    });
+
     it("update destination", async () => {
       const oldDest = await payroll.liqDestinations(testToken.address);
       const tx = await payroll.updateDestination(testToken.address, newAddress);


### PR DESCRIPTION
- admin can update the eth liquidation address
- revert on `updateDestination` for an address that is not a whitelisted token